### PR TITLE
Use rfkill to unblock bluetooth adapter

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -31,6 +31,9 @@ toggle_power() {
         bluetoothctl power off
         show_menu
     else
+        if rfkill list bluetooth | grep -q 'blocked: yes'; then
+            rfkill unblock bluetooth && sleep 3
+        fi
         bluetoothctl power on
         show_menu
     fi


### PR DESCRIPTION
Power management tools such as TLP would not only power off the
bluetooth adapter using bluetoothctl but also block it using rfkill.

This patch checks if the radio device is blocked using rfkill, and
unblocks it in case it was. Note that after unblocking, the bluetooth
subsystem needs a couple seconds to initialize, therefore 'sleep 3'.

There is no additional dependencies introduced with this patch; rfkill
is part of util-linux, of which the base system depends.