### PR TITLE
Use different icons for on and off states

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -179,7 +179,7 @@ toggle_trust() {
 # Useful for status bars like polybar, etc.
 print_status() {
     if power_on; then
-        printf ''
+        printf ''
 
         mapfile -t paired_devices < <(bluetoothctl paired-devices | grep Device | cut -d ' ' -f 2)
         counter=0
@@ -198,11 +198,8 @@ print_status() {
             fi
         done
 
-       if [ $counter -eq 0 ]; then
-           printf " On"
-       fi
     else
-        echo " Off"
+        echo ""
     fi
 }
 


### PR DESCRIPTION
Hi @ClydeDroid , first of all thank you so much for this repo. 

In this PR I added different visual indicators for "On" and "Off" state which I felt might be nice instead of text.

Here's how they look with this patch:

On and connected to a device:
![s_2021-02-18_011033](https://user-images.githubusercontent.com/2682729/108260602-883b2300-7188-11eb-8bcc-af9cbdc09810.png)

On:  
![s_2021-02-18_013258](https://user-images.githubusercontent.com/2682729/108261181-42cb2580-7189-11eb-9f8f-dbcec22c9dce.png)


Off: 
![s_2021-02-18_010835](https://user-images.githubusercontent.com/2682729/108260612-8a04e680-7188-11eb-8b54-c2c842621fd9.png)

I copied the glyphs from the [nerd font cheatsheet](https://www.nerdfonts.com/cheat-sheet).

Additionally, we could have three different icons for the three states along with maybe a blue colored icon for the "connected to a device state". But that change would be slightly more involved than a few character changes especially around the logic to print multiple connected devices. I did not want to start working on that without discussing about it with you first. Let me know what you think. :smile: 