### PR TITLE
fix(menu): Work with devices with [] in name

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -296,7 +296,7 @@ show_menu() {
             toggle_pairable
             ;;
         *)
-            device=$(bluetoothctl devices | grep "$chosen")
+            device=$(bluetoothctl devices | grep -F "$chosen")
             # Open a submenu if a device is selected
             if [[ $device ]]; then device_menu "$device"; fi
             ;;


### PR DESCRIPTION
If a device has characters like `[]` in names or in general names that can be mistaken for a grep expression, the search for the chosen device might not work properly. `grep -F` fixes this.