### PR TITLE
fix: wrap bluetoothctl calls for BlueZ >= 5.86 compatibility

### DIFF
--- a/rofi-bluetooth
+++ b/rofi-bluetooth
@@ -20,297 +20,309 @@
 divider="---------"
 goback="Back"
 
+# Wrapper around bluetoothctl to work around BlueZ >= 5.86 breaking
+# non-interactive subcommand invocations (e.g. `bluetoothctl show`
+# returning no output). Piping the command via stdin preserves
+# compatibility with both old and new versions.
+# Strips ANSI escape sequences, carriage returns, and interactive noise
+# (prompts, agent registration, D-Bus events) from the output.
+_bluetoothctl() {
+   echo "$*" | bluetoothctl 2>/dev/null \
+       | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\r//g' \
+       | grep -v -E '^\[.*\]>|^Waiting to connect|^Agent registered|^\[NEW\]|^\[DEL\]|^\[CHG\]|^$'
+}
+
 # Checks if bluetooth controller is powered on
 power_on() {
-    if bluetoothctl show | grep -q "Powered: yes"; then
-        return 0
-    else
-        return 1
-    fi
+   if _bluetoothctl show | grep -q "Powered: yes"; then
+       return 0
+   else
+       return 1
+   fi
 }
 
 # Toggles power state
 toggle_power() {
-    if power_on; then
-        bluetoothctl power off
-        show_menu
-    else
-        if rfkill list bluetooth | grep -q 'blocked: yes'; then
-            rfkill unblock bluetooth && sleep 3
-        fi
-        bluetoothctl power on
-        show_menu
-    fi
+   if power_on; then
+       _bluetoothctl power off
+       show_menu
+   else
+       if rfkill list bluetooth | grep -q 'blocked: yes'; then
+           rfkill unblock bluetooth && sleep 3
+       fi
+       _bluetoothctl power on
+       show_menu
+   fi
 }
 
 # Checks if controller is scanning for new devices
 scan_on() {
-    if bluetoothctl show | grep -q "Discovering: yes"; then
-        echo "Scan: on"
-        return 0
-    else
-        echo "Scan: off"
-        return 1
-    fi
+   if _bluetoothctl show | grep -q "Discovering: yes"; then
+       echo "Scan: on"
+       return 0
+   else
+       echo "Scan: off"
+       return 1
+   fi
 }
 
 # Toggles scanning state
 toggle_scan() {
-    if scan_on; then
-        kill $(pgrep -f "bluetoothctl --timeout 5 scan on")
-        bluetoothctl scan off
-        show_menu
-    else
-        bluetoothctl --timeout 5 scan on
-        echo "Scanning..."
-        show_menu
-    fi
+   if scan_on; then
+       kill $(pgrep -f "bluetoothctl --timeout 5 scan on")
+       _bluetoothctl scan off
+       show_menu
+   else
+       bluetoothctl --timeout 5 scan on &
+       echo "Scanning..."
+       show_menu
+   fi
 }
 
 # Checks if controller is able to pair to devices
 pairable_on() {
-    if bluetoothctl show | grep -q "Pairable: yes"; then
-        echo "Pairable: on"
-        return 0
-    else
-        echo "Pairable: off"
-        return 1
-    fi
+   if _bluetoothctl show | grep -q "Pairable: yes"; then
+       echo "Pairable: on"
+       return 0
+   else
+       echo "Pairable: off"
+       return 1
+   fi
 }
 
 # Toggles pairable state
 toggle_pairable() {
-    if pairable_on; then
-        bluetoothctl pairable off
-        show_menu
-    else
-        bluetoothctl pairable on
-        show_menu
-    fi
+   if pairable_on; then
+       _bluetoothctl pairable off
+       show_menu
+   else
+       _bluetoothctl pairable on
+       show_menu
+   fi
 }
 
 # Checks if controller is discoverable by other devices
 discoverable_on() {
-    if bluetoothctl show | grep -q "Discoverable: yes"; then
-        echo "Discoverable: on"
-        return 0
-    else
-        echo "Discoverable: off"
-        return 1
-    fi
+   if _bluetoothctl show | grep -q "Discoverable: yes"; then
+       echo "Discoverable: on"
+       return 0
+   else
+       echo "Discoverable: off"
+       return 1
+   fi
 }
 
 # Toggles discoverable state
 toggle_discoverable() {
-    if discoverable_on; then
-        bluetoothctl discoverable off
-        show_menu
-    else
-        bluetoothctl discoverable on
-        show_menu
-    fi
+   if discoverable_on; then
+       _bluetoothctl discoverable off
+       show_menu
+   else
+       _bluetoothctl discoverable on
+       show_menu
+   fi
 }
 
 # Checks if a device is connected
 device_connected() {
-    device_info=$(bluetoothctl info "$1")
-    if echo "$device_info" | grep -q "Connected: yes"; then
-        return 0
-    else
-        return 1
-    fi
+   device_info=$(_bluetoothctl info "$1")
+   if echo "$device_info" | grep -q "Connected: yes"; then
+       return 0
+   else
+       return 1
+   fi
 }
 
 # Toggles device connection
 toggle_connection() {
-    if device_connected "$1"; then
-        bluetoothctl disconnect "$1"
-        device_menu "$device"
-    else
-        bluetoothctl connect "$1"
-        device_menu "$device"
-    fi
+   if device_connected "$1"; then
+       _bluetoothctl disconnect "$1"
+       device_menu "$device"
+   else
+       _bluetoothctl connect "$1"
+       device_menu "$device"
+   fi
 }
 
 # Checks if a device is paired
 device_paired() {
-    device_info=$(bluetoothctl info "$1")
-    if echo "$device_info" | grep -q "Paired: yes"; then
-        echo "Paired: yes"
-        return 0
-    else
-        echo "Paired: no"
-        return 1
-    fi
+   device_info=$(_bluetoothctl info "$1")
+   if echo "$device_info" | grep -q "Paired: yes"; then
+       echo "Paired: yes"
+       return 0
+   else
+       echo "Paired: no"
+       return 1
+   fi
 }
 
 # Toggles device paired state
 toggle_paired() {
-    if device_paired "$1"; then
-        bluetoothctl remove "$1"
-        device_menu "$device"
-    else
-        bluetoothctl pair "$1"
-        device_menu "$device"
-    fi
+   if device_paired "$1"; then
+       _bluetoothctl remove "$1"
+       device_menu "$device"
+   else
+       _bluetoothctl pair "$1"
+       device_menu "$device"
+   fi
 }
 
 # Checks if a device is trusted
 device_trusted() {
-    device_info=$(bluetoothctl info "$1")
-    if echo "$device_info" | grep -q "Trusted: yes"; then
-        echo "Trusted: yes"
-        return 0
-    else
-        echo "Trusted: no"
-        return 1
-    fi
+   device_info=$(_bluetoothctl info "$1")
+   if echo "$device_info" | grep -q "Trusted: yes"; then
+       echo "Trusted: yes"
+       return 0
+   else
+       echo "Trusted: no"
+       return 1
+   fi
 }
 
 # Toggles device connection
 toggle_trust() {
-    if device_trusted "$1"; then
-        bluetoothctl untrust "$1"
-        device_menu "$device"
-    else
-        bluetoothctl trust "$1"
-        device_menu "$device"
-    fi
+   if device_trusted "$1"; then
+       _bluetoothctl untrust "$1"
+       device_menu "$device"
+   else
+       _bluetoothctl trust "$1"
+       device_menu "$device"
+   fi
 }
 
 # Prints a short string with the current bluetooth status
 # Useful for status bars like polybar, etc.
 print_status() {
-    if power_on; then
-        printf ''
+   if power_on; then
+       printf ''
 
-        paired_devices_cmd="devices Paired"
-        # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
-            paired_devices_cmd="paired-devices"
-        fi
+       paired_devices_cmd="devices Paired"
+       # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
+       if (( $(echo "$(_bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+           paired_devices_cmd="paired-devices"
+       fi
 
-        mapfile -t paired_devices < <(bluetoothctl $paired_devices_cmd | grep Device | cut -d ' ' -f 2)
-        counter=0
+       mapfile -t paired_devices < <(_bluetoothctl $paired_devices_cmd | grep Device | cut -d ' ' -f 2)
+       counter=0
 
-        for device in "${paired_devices[@]}"; do
-            if device_connected "$device"; then
-                device_alias=$(bluetoothctl info "$device" | grep "Alias" | cut -d ' ' -f 2-)
+       for device in "${paired_devices[@]}"; do
+           if device_connected "$device"; then
+               device_alias=$(_bluetoothctl info "$device" | grep "Alias" | cut -d ' ' -f 2-)
 
-                if [ $counter -gt 0 ]; then
-                    printf ", %s" "$device_alias"
-                else
-                    printf " %s" "$device_alias"
-                fi
+               if [ $counter -gt 0 ]; then
+                   printf ", %s" "$device_alias"
+               else
+                   printf " %s" "$device_alias"
+               fi
 
-                ((counter++))
-            fi
-        done
-        printf "\n"
-    else
-        echo ""
-    fi
+               ((counter++))
+           fi
+       done
+       printf "\n"
+   else
+       echo ""
+   fi
 }
 
 # A submenu for a specific device that allows connecting, pairing, and trusting
 device_menu() {
-    device=$1
+   device=$1
 
-    # Get device name and mac address
-    device_name=$(echo "$device" | cut -d ' ' -f 3-)
-    mac=$(echo "$device" | cut -d ' ' -f 2)
+   # Get device name and mac address
+   device_name=$(echo "$device" | cut -d ' ' -f 3-)
+   mac=$(echo "$device" | cut -d ' ' -f 2)
 
-    # Build options
-    if device_connected "$mac"; then
-        connected="Connected: yes"
-    else
-        connected="Connected: no"
-    fi
-    paired=$(device_paired "$mac")
-    trusted=$(device_trusted "$mac")
-    options="$connected\n$paired\n$trusted\n$divider\n$goback\nExit"
+   # Build options
+   if device_connected "$mac"; then
+       connected="Connected: yes"
+   else
+       connected="Connected: no"
+   fi
+   paired=$(device_paired "$mac")
+   trusted=$(device_trusted "$mac")
+   options="$connected\n$paired\n$trusted\n$divider\n$goback\nExit"
 
-    # Open rofi menu, read chosen option
-    chosen="$(echo -e "$options" | $rofi_command "$device_name")"
+   # Open rofi menu, read chosen option
+   chosen="$(echo -e "$options" | $rofi_command "$device_name")"
 
-    # Match chosen option to command
-    case "$chosen" in
-        "" | "$divider")
-            echo "No option chosen."
-            ;;
-        "$connected")
-            toggle_connection "$mac"
-            ;;
-        "$paired")
-            toggle_paired "$mac"
-            ;;
-        "$trusted")
-            toggle_trust "$mac"
-            ;;
-        "$goback")
-            show_menu
-            ;;
-    esac
+   # Match chosen option to command
+   case "$chosen" in
+       "" | "$divider")
+           echo "No option chosen."
+           ;;
+       "$connected")
+           toggle_connection "$mac"
+           ;;
+       "$paired")
+           toggle_paired "$mac"
+           ;;
+       "$trusted")
+           toggle_trust "$mac"
+           ;;
+       "$goback")
+           show_menu
+           ;;
+   esac
 }
 
 # Opens a rofi menu with current bluetooth status and options to connect
 show_menu() {
-    # Get menu options
-    if power_on; then
-        power="Power: on"
+   # Get menu options
+   if power_on; then
+       power="Power: on"
 
-        # Human-readable names of devices, one per line
-        # If scan is off, will only list paired devices
-        devices=$(bluetoothctl devices | grep Device | cut -d ' ' -f 3-)
+       # Human-readable names of devices, one per line
+       # If scan is off, will only list paired devices
+       devices=$(_bluetoothctl devices | grep Device | cut -d ' ' -f 3-)
 
-        # Get controller flags
-        scan=$(scan_on)
-        pairable=$(pairable_on)
-        discoverable=$(discoverable_on)
+       # Get controller flags
+       scan=$(scan_on)
+       pairable=$(pairable_on)
+       discoverable=$(discoverable_on)
 
-        # Options passed to rofi
-        options="$devices\n$divider\n$power\n$scan\n$pairable\n$discoverable\nExit"
-    else
-        power="Power: off"
-        options="$power\nExit"
-    fi
+       # Options passed to rofi
+       options="$devices\n$divider\n$power\n$scan\n$pairable\n$discoverable\nExit"
+   else
+       power="Power: off"
+       options="$power\nExit"
+   fi
 
-    # Open rofi menu, read chosen option
-    chosen="$(echo -e "$options" | $rofi_command "Bluetooth")"
+   # Open rofi menu, read chosen option
+   chosen="$(echo -e "$options" | $rofi_command "Bluetooth")"
 
-    # Match chosen option to command
-    case "$chosen" in
-        "" | "$divider")
-            echo "No option chosen."
-            ;;
-        "$power")
-            toggle_power
-            ;;
-        "$scan")
-            toggle_scan
-            ;;
-        "$discoverable")
-            toggle_discoverable
-            ;;
-        "$pairable")
-            toggle_pairable
-            ;;
-        *)
-            device=$(bluetoothctl devices | grep "$chosen")
-            # Open a submenu if a device is selected
-            if [[ $device ]]; then device_menu "$device"; fi
-            ;;
-    esac
+   # Match chosen option to command
+   case "$chosen" in
+       "" | "$divider")
+           echo "No option chosen."
+           ;;
+       "$power")
+           toggle_power
+           ;;
+       "$scan")
+           toggle_scan
+           ;;
+       "$discoverable")
+           toggle_discoverable
+           ;;
+       "$pairable")
+           toggle_pairable
+           ;;
+       *)
+           device=$(_bluetoothctl devices | grep "$chosen")
+           # Open a submenu if a device is selected
+           if [[ $device ]]; then device_menu "$device"; fi
+           ;;
+   esac
 }
 
 # Rofi command to pipe into, can add any options here
 rofi_command="rofi -dmenu $* -p"
 
 case "$1" in
-    --status)
-        print_status
-        ;;
-    *)
-        show_menu
-        ;;
+   --status)
+       print_status
+       ;;
+   *)
+       show_menu
+       ;;
 esac


### PR DESCRIPTION
BlueZ 5.86 broke non-interactive bluetoothctl subcommand invocations (e.g. 'bluetoothctl show' returns no output). This adds a _bluetoothctl() wrapper that pipes commands via stdin, which works on both old and new versions. Fixed output formatting from previous version.